### PR TITLE
Added custom FileLoader to fix overwrite problem

### DIFF
--- a/src/BaseTranslationServiceProvider.php
+++ b/src/BaseTranslationServiceProvider.php
@@ -55,7 +55,7 @@
             });
 
             $this->app->singleton('translation.loader.custom', function ($app) {
-                return new CustomLangLoader($app['files'], $app['chained-translator.path.lang.custom']);
+                return new NonPackageFileLoader($app['files'], $app['chained-translator.path.lang.custom']);
             });
 
             //override the Laravel translation loader singleton:

--- a/src/BaseTranslationServiceProvider.php
+++ b/src/BaseTranslationServiceProvider.php
@@ -55,7 +55,7 @@
             });
 
             $this->app->singleton('translation.loader.custom', function ($app) {
-                return new FileLoader($app['files'], $app['chained-translator.path.lang.custom']);
+                return new CustomLangLoader($app['files'], $app['chained-translator.path.lang.custom']);
             });
 
             //override the Laravel translation loader singleton:

--- a/src/CustomLangLoader.php
+++ b/src/CustomLangLoader.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Statikbe\LaravelChainedTranslator;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Translation\FileLoader;
+
+class CustomLangLoader extends FileLoader
+{
+    public function __construct(Filesystem $files, $path)
+    {
+        parent::__construct($files, $path);
+    }
+
+    protected function loadNamespaced($locale, $group, $namespace)
+    {
+        if(isset($this->hints[$namespace])) {
+            return $this->loadNamespaceOverrides([], $locale, $group, $namespace);
+        }
+
+        return [];
+    }
+}

--- a/src/NonPackageFileLoader.php
+++ b/src/NonPackageFileLoader.php
@@ -5,16 +5,14 @@ namespace Statikbe\LaravelChainedTranslator;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Translation\FileLoader;
 
-class CustomLangLoader extends FileLoader
+class NonPackageFileLoader extends FileLoader
 {
-    public function __construct(Filesystem $files, $path)
-    {
-        parent::__construct($files, $path);
-    }
-
     protected function loadNamespaced($locale, $group, $namespace)
     {
         if(isset($this->hints[$namespace])) {
+            //We removed the line from FileLoader that loads the translations from the packages in the /vendor folder.
+            //This is to avoid overwriting published vendor translations done in the default /lang/vendor folder,
+            //with the translations provided by the packages themselves in /vendor.
             return $this->loadNamespaceOverrides([], $locale, $group, $namespace);
         }
 


### PR DESCRIPTION
Added a custom FileLoader which fixes published vendor translations being overwritten by the package's defaults.